### PR TITLE
always return a { code, map } object

### DIFF
--- a/src/builders/amd.js
+++ b/src/builders/amd.js
@@ -1,11 +1,16 @@
 import createBody from '../utils/createBody';
+import deprecateToString from '../utils/deprecateToString';
+
+const getImportPath = imported => imported.href.replace( /\.[a-zA-Z]+$/, '' );
+const quote = str => `"${str}"`;
+const getDependencyName = ( x, i ) => `__import${i}__`;
 
 export default function amd ( definition ) {
-	var dependencies, builtModule, { intro, body, outro } = createBody( definition );
+	const { intro, body, outro } = createBody( definition );
 
-	dependencies = definition.imports.map( getImportPath ).concat( definition.modules );
+	const dependencies = definition.imports.map( getImportPath ).concat( definition.modules );
 
-	builtModule = '' +
+	const code = '' +
 `define([
 	${dependencies.map( quote ).concat( '"require"', '"ractive"' ).join( ',\n\t' )}
 ], function(
@@ -19,17 +24,7 @@ ${outro}
 	return __export__;
 });`;
 
-	return builtModule;
-}
+	// TODO sourcemap support
 
-function getImportPath ( imported ) {
-	return imported.href.replace( /\.[a-zA-Z]+$/, '' );
-}
-
-function quote ( str ) {
-	return `"${str}"`;
-}
-
-function getDependencyName ( imported, i ) {
-	return `__import${i}__`;
+	return deprecateToString( code, null, 'amd' );
 }

--- a/src/builders/cjs.js
+++ b/src/builders/cjs.js
@@ -1,20 +1,23 @@
 import createBody from '../utils/createBody';
+import deprecateToString from '../utils/deprecateToString';
 
 export default function cjs ( definition ) {
-	var requireStatements, builtModule, { intro, body, outro } = createBody( definition );
+	const { intro, body, outro } = createBody( definition );
 
-	requireStatements = definition.imports.map( function ( imported, i ) {
+	let requireStatements = definition.imports.map( function ( imported, i ) {
 		var path = imported.href.replace( /\.[a-zA-Z]+$/, '' );
 		return `__import${i}__ = require('${path}')`;
 	});
 
 	requireStatements.unshift( `Ractive = require('ractive')` );
 
-	builtModule = 'var ' + requireStatements.join( ',\n\t' ) + ';\n\n' +
+	const code = 'var ' + requireStatements.join( ',\n\t' ) + ';\n\n' +
 	intro +
 	body +
 	outro +
 	'module.exports = __export__;';
 
-	return builtModule;
+	// TODO sourcemap support
+
+	return deprecateToString( code, null, 'cjs' );
 }

--- a/src/builders/es6.js
+++ b/src/builders/es6.js
@@ -1,5 +1,6 @@
 import { generateSourceMap } from 'rcu';
 import createBody from '../utils/createBody';
+import deprecateToString from '../utils/deprecateToString';
 
 export default function es6 ( definition, options = {} ) {
 	let { intro, body, outro } = createBody( definition );
@@ -62,22 +63,21 @@ export default function es6 ( definition, options = {} ) {
 		exportBlock
 	].join( '\n' );
 
-	let builtModule = [
+	const code = [
 		beforeScript,
 		body,
 		afterScript
 	].join( '\n' );
 
-	if ( options.sourceMap && definition.script ) {
-		let sourceMap = generateSourceMap( definition, {
-			padding: beforeScript.split( '\n' ).length,
+	const map = options.sourceMap ?
+		generateSourceMap( definition, {
+			offset: beforeScript.split( '\n' ).length,
+			hires: options.hires !== false,
 			file: options.sourceMapFile,
 			source: options.sourceMapSource,
 			content: definition.source
-		});
+		}) :
+		null;
 
-		builtModule += '\n\/\/# sourceMappingURL=' + sourceMap.toUrl();
-	}
-
-	return builtModule;
+	return deprecateToString( code, map, 'es6' );
 }

--- a/src/utils/deprecateToString.js
+++ b/src/utils/deprecateToString.js
@@ -1,0 +1,15 @@
+let alreadyWarned = false;
+
+export default function deprecateToString ( code, map, type ) {
+	return {
+		code, map,
+		toString () {
+			if ( !alreadyWarned ) {
+				console.error( `As of 0.4.0, rcu-builders.${type} returns a { code, map } object, rather than returning code directly` ); // eslint-disable-line no-console
+				alreadyWarned = true;
+			}
+
+			return code;
+		}
+	};
+}


### PR DESCRIPTION
...rather than appending an inline sourcemap if one is created. It's generally easier for downstream tools to work with sourcemaps that way. Currently only the `es6` builder actually generates a sourcemap, but all three builders return an object for future-proofing and consistency.

To minimise breakage the object has a `toString` property that prints a deprecation warning and returns `code`.
