### PR TITLE
Export rcu

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ npm i rcu-builders
 ## Usage
 
 ```js
-var rcu = require( 'rcu' );
 var builders = require( 'rcu-builders' );
+var rcu = require( 'rcu' ); // You can use your own rcu
+var rcu = builders.rcu; // Or the exported one
 var Ractive = require( 'ractive' );
 
 // Initialise ractive component utils

--- a/src/index.js
+++ b/src/index.js
@@ -2,4 +2,5 @@ import amd from './builders/amd';
 import cjs from './builders/cjs';
 import es6 from './builders/es6';
 
+export { default as rcu } from 'rcu';
 export { amd, cjs, es6 };


### PR DESCRIPTION
Because this module can _only_ be used in conjunction with `rcu`, and it's already used inside the module, why not export it so the `rcu` and `rcu-builders` versions are guaranteed to be in sync, and implementers don't have to maintain yet another dependency.
